### PR TITLE
add private convenience method for ad-hoc debugging

### DIFF
--- a/wagtail_localize_rws_languagecloud/rws_client.py
+++ b/wagtail_localize_rws_languagecloud/rws_client.py
@@ -245,3 +245,21 @@ class ApiClient:
         if should_sleep:
             sleep(self.api_sleep_seconds)
         return r.json()
+
+    def _get(self, url):
+        """
+        Generic get method. This is mainly here to make ad-hoc debugging easier.
+        It is not called anywhere
+        """
+        self.logger.debug("get")
+        if not self.is_authenticated:
+            raise NotAuthenticated()
+
+        r = requests.get(
+            f"{self.api_base}/{url}",
+            headers=self.headers,
+            timeout=REQUEST_TIMEOUT,
+        )
+        self.logger.debug(r.text)
+        r.raise_for_status()
+        return r.json()


### PR DESCRIPTION
Sometimes when we're following up on issues for Twilio its necessary to make some ad-hoc API queries to inspect things. In the past I've been doing this with curl, but constructing ad-hoc curl requests with this API can be a bit of a pain given the OAuth Bearer token is 756 characters long. The last couple of times I've just defined a quick method on the RWS client object which allows me to do stuff like

```
$ ./manage.py shell

>>> from wagtail_localize_rws_languagecloud.rws_client import ApiClient
>>> client = ApiClient()
>>> client.authenticate()
>>> client._get('projects/61bc94d025abab4aa098a61e/source-files?fields=targetLanguages,language,name')
>>> exit()
```

which made things a lot easier :)

What do you think to including this in the codebase (even though we're not actually calling it anywhere) just to make debugging easier?