### PR TITLE
Set LanguageCloud project status to complete

### DIFF
--- a/wagtail_localize_rws_languagecloud/sync.py
+++ b/wagtail_localize_rws_languagecloud/sync.py
@@ -357,9 +357,12 @@ def _import(client, logger):
             if db_project.all_files_imported:
                 db_project.internal_status = LanguageCloudProject.STATUS_IMPORTED
                 db_project.save()
+
                 if api_project["status"] != "completed":
                     try:
                         client.complete_project(db_project.lc_project_id)
+                        db_project.lc_project_status = LanguageCloudStatus.COMPLETED
+                        db_project.save()
                     except (RequestException):
                         pass
         except (KeyboardInterrupt, SystemExit):

--- a/wagtail_localize_rws_languagecloud/tests/test_sync.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_sync.py
@@ -80,6 +80,7 @@ class TestImport(TestCase):
         for proj in self.lc_projects:
             proj.refresh_from_db()
             self.assertEqual(proj.internal_status, LanguageCloudProject.STATUS_IMPORTED)
+            self.assertEqual(proj.lc_project_status, LanguageCloudStatus.COMPLETED)
         for file_ in self.lc_files:
             file_.refresh_from_db()
             self.assertEqual(file_.internal_status, LanguageCloudFile.STATUS_IMPORTED)
@@ -138,6 +139,9 @@ class TestImport(TestCase):
             self.lc_projects[1].internal_status, LanguageCloudProject.STATUS_IMPORTED
         )
         self.assertEqual(
+            self.lc_projects[1].lc_project_status, LanguageCloudStatus.COMPLETED
+        )
+        self.assertEqual(
             self.lc_files[1].internal_status, LanguageCloudFile.STATUS_IMPORTED
         )
         self.assertEqual(
@@ -184,6 +188,9 @@ class TestImport(TestCase):
         self.lc_projects[0].refresh_from_db()
         self.assertEqual(
             self.lc_projects[0].internal_status, LanguageCloudProject.STATUS_IMPORTED
+        )
+        self.assertEqual(
+            self.lc_projects[0].lc_project_status, LanguageCloudStatus.COMPLETED
         )
 
         self.lc_projects[1].refresh_from_db()


### PR DESCRIPTION
Set `lc_project_status` to complete when we mark it as complete on LanguageCloud.

This is so that our local state matches RWS LanguageCloud.