### PR TITLE
Support custom User models

### DIFF
--- a/wagtail_localize_rws_languagecloud/emails.py
+++ b/wagtail_localize_rws_languagecloud/emails.py
@@ -1,7 +1,9 @@
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy
 from wagtail.admin.mail import send_mail
+
+User = get_user_model()
 
 
 def get_full_url(url):


### PR DESCRIPTION
Email sending currently fails when the project has a custom User model.

This change replaces the direct `User` import with `get_user_model`.