### PR TITLE
Add `translation_imported` signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add `translation_imported` signal that is triggered when a translation is
+  successfully imported from RWS LanguageCloud.
+
 ## [0.6] - 2022-02-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,22 +94,26 @@ This signal is sent when a translation from RWS LanguageCloud is successfully im
 
 - **sender:** `LanguageCloudProject`
 - **instance:** The specific `LanguageCloudProject` instance.
-- **translation_source_object:** The page or snippet instance that this translation is for.
+- **source_object:** The page or snippet instance that this translation is for.
+- **translated_object:** The translated instance of the page or snippet.
 
 Here’s how you could use it to send Slack notifications.
 
 ```python
+from wagtail_localize.models import get_edit_url
 from wagtail_localize_rws_languagecloud.signals import translation_imported
 import requests
 
 # Let everyone know when translations come back from RWS LanguageCloud
-def send_to_slack(sender, instance, translation_source_object):
+def send_to_slack(sender, instance, source_object, translated_object, **kwargs):
     url = (
         "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
     )
 
+    edit_url = "https://www.mysite.com" + get_edit_url(translated_object)
+
     values = {
-        "text": f'New translations for "{translation_source_object}" have been imported.',
+        "text": f"Translated content for '{translated_object}' is ready for review at: {edit_url}",
         "channel": "#translation-notifications",
         "username": "Wagtail",
         "icon_emoji": ":rocket:",
@@ -121,6 +125,8 @@ def send_to_slack(sender, instance, translation_source_object):
 # Register a receiver
 translation_imported.connect(send_to_slack)
 ```
+
+For more information on signal handlers, see [the Django docs](https://docs.djangoproject.com/en/stable/topics/signals/#connecting-receiver-functions).
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,44 @@ This can be run on a regular basis using a scheduler like cron. We recommend an 
 - If using cron as a scheduler, [lockrun](http://unixwiz.net/tools/lockrun.html) can be used to prevent multiple instance of the same job running simultaneously.
 - If using a queue-based scheduler like Celery Beat, the `SyncManager` class contains `is_queued` and `is_running` extension points which could be used to implement a lock strategy.
 
+## Signals
+
+`translation_imported`
+
+This signal is sent when a translation from RWS LanguageCloud is successfully imported.
+
+**Arguments:**
+
+- **sender:** `LanguageCloudProject`
+- **instance:** The specific `LanguageCloudProject` instance.
+- **translation_source_object:** The page or snippet instance that this translation is for.
+
+Here’s how you could use it to send Slack notifications.
+
+```python
+from wagtail_localize_rws_languagecloud.signals import translation_imported
+import requests
+
+# Let everyone know when translations come back from RWS LanguageCloud
+def send_to_slack(sender, instance, translation_source_object):
+    url = (
+        "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    )
+
+    values = {
+        "text": f'New translations for "{translation_source_object}" have been imported.',
+        "channel": "#translation-notifications",
+        "username": "Wagtail",
+        "icon_emoji": ":rocket:",
+    }
+
+    requests.post(url, values)
+
+
+# Register a receiver
+translation_imported.connect(send_to_slack)
+```
+
 ## How it works
 
 This plugin uses `wagtail-localize` to convert pages into segments and build new pages from translated segments. `wagtail-localize` provides a web interface for translating these segments in Wagtail itself and this plugin plays nicely with that (translations can be made from the Wagtail side too).

--- a/wagtail_localize_rws_languagecloud/signals.py
+++ b/wagtail_localize_rws_languagecloud/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+
+translation_imported = Signal()

--- a/wagtail_localize_rws_languagecloud/sync.py
+++ b/wagtail_localize_rws_languagecloud/sync.py
@@ -16,6 +16,7 @@ from .models import (
     LanguageCloudStatus,
 )
 from .rws_client import ApiClient, NotFound
+from .signals import translation_imported
 
 
 def _get_project_templates_and_locations(client: ApiClient):
@@ -357,6 +358,12 @@ def _import(client, logger):
             if db_project.all_files_imported:
                 db_project.internal_status = LanguageCloudProject.STATUS_IMPORTED
                 db_project.save()
+
+                translation_imported.send(
+                    sender=LanguageCloudProject,
+                    instance=db_project,
+                    translation_source_object=db_project.translation_source_object,
+                )
 
                 if api_project["status"] != "completed":
                     try:

--- a/wagtail_localize_rws_languagecloud/sync.py
+++ b/wagtail_localize_rws_languagecloud/sync.py
@@ -337,6 +337,13 @@ def _import(client, logger):
                         "SEND_EMAILS", False
                     ):
                         send_emails(db_source_file.translation)
+
+                    translation_imported.send(
+                        sender=LanguageCloudProject,
+                        instance=db_project,
+                        source_object=db_project.translation_source_object,
+                        translated_object=db_source_file.translation.get_target_instance(),
+                    )
                 except SuspiciousOperation as e:
                     logger.exception(e)
                     db_source_file.internal_status = LanguageCloudFile.STATUS_ERROR
@@ -358,12 +365,6 @@ def _import(client, logger):
             if db_project.all_files_imported:
                 db_project.internal_status = LanguageCloudProject.STATUS_IMPORTED
                 db_project.save()
-
-                translation_imported.send(
-                    sender=LanguageCloudProject,
-                    instance=db_project,
-                    translation_source_object=db_project.translation_source_object,
-                )
 
                 if api_project["status"] != "completed":
                     try:

--- a/wagtail_localize_rws_languagecloud/tests/test_signals.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_signals.py
@@ -1,0 +1,85 @@
+import logging
+
+from unittest.mock import MagicMock, Mock
+
+from django.test import TestCase
+from wagtail.core.models import Locale
+
+import wagtail_localize_rws_languagecloud.sync as sync
+
+from wagtail_localize.models import Translation
+
+from ..models import LanguageCloudFile, LanguageCloudProject, LanguageCloudStatus
+from ..rws_client import ApiClient
+from ..signals import translation_imported
+from .helpers import create_test_page, create_test_po
+
+
+class TestSignals(TestCase):
+    def setUp(self):
+        self.po_file = create_test_po(
+            [
+                (
+                    "test_charfield",
+                    "Some test translatable content",
+                    "Certains tests de contenu traduisible",
+                )
+            ]
+        )
+        locale_fr = Locale.objects.create(language_code="fr")
+        self.page, source = create_test_page(
+            title="Test page",
+            slug="test-page",
+            test_charfield="Some test translatable content",
+        )
+        translation = Translation.objects.create(
+            source=source,
+            target_locale=locale_fr,
+        )
+        self.project = LanguageCloudProject.objects.create(
+            translation_source=source,
+            source_last_updated_at=source.last_updated_at,
+            internal_status=LanguageCloudProject.STATUS_NEW,
+            lc_project_id="proj",
+        )
+        LanguageCloudFile.objects.create(
+            translation=translation,
+            project=self.project,
+            lc_source_file_id="file",
+            internal_status=LanguageCloudFile.STATUS_NEW,
+        )
+
+        self.logger = logging.getLogger(__name__)
+        logging.disable()  # supress log output under test
+
+    def test_translation_imported_signal(self):
+        # Create signal handler
+        signal_handler = MagicMock()
+        translation_imported.connect(signal_handler)
+
+        # Set up mocks
+        client = ApiClient()
+        client.is_authorized = True
+        client.get_project = Mock(
+            side_effect=[{"status": "completed"}, {"status": "inProgress"}], spec=True
+        )
+        client.download_target_file = Mock(side_effect=[str(self.po_file)], spec=True)
+        client.complete_project = Mock(spec=True)
+
+        # Run sync import
+        sync._import(client, self.logger)
+
+        # Check sync import worked
+        self.project.refresh_from_db()
+        self.assertEqual(
+            self.project.internal_status, LanguageCloudProject.STATUS_IMPORTED
+        )
+        self.assertEqual(self.project.lc_project_status, LanguageCloudStatus.COMPLETED)
+
+        # Check signal handler was called
+        signal_handler.assert_called_once_with(
+            signal=translation_imported,
+            sender=LanguageCloudProject,
+            instance=self.project,
+            translation_source_object=self.page,
+        )

--- a/wagtail_localize_rws_languagecloud/tests/test_signals.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_signals.py
@@ -26,7 +26,7 @@ class TestSignals(TestCase):
                 )
             ]
         )
-        locale_fr = Locale.objects.create(language_code="fr")
+        self.locale_fr = Locale.objects.create(language_code="fr")
         self.page, source = create_test_page(
             title="Test page",
             slug="test-page",
@@ -34,7 +34,7 @@ class TestSignals(TestCase):
         )
         translation = Translation.objects.create(
             source=source,
-            target_locale=locale_fr,
+            target_locale=self.locale_fr,
         )
         self.project = LanguageCloudProject.objects.create(
             translation_source=source,
@@ -81,5 +81,6 @@ class TestSignals(TestCase):
             signal=translation_imported,
             sender=LanguageCloudProject,
             instance=self.project,
-            translation_source_object=self.page,
+            source_object=self.page,
+            translated_object=self.page.get_translation(self.locale_fr),
         )


### PR DESCRIPTION
This PR adds a new signal called `translation_imported` that is triggered whenever an RWS LangageCloud project is successfully imported.