### PR TITLE
Fix: Handle pages with special characters in the title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 /node_modules
 /test-static
 /test-media
+local_settings.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Strip special characters in LanguageCloud project names
+
 ## [0.7] - 2022-03-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -162,3 +162,16 @@ $ pre-commit install
 # Optional, run all checks once for this, then the checks will run only on the changed files
 $ pre-commit run --all-files
 ```
+
+### local_settings.py
+
+You can add a `local_settings.py` file next to `settings.py` for any settings that you need when running the project locally.
+
+For example, you might want to set a `NAME` for the SQLite test database so that `--keepdb` works.
+
+```python
+# wagtail_localize_rws_languagecloud/test/local_settings.py
+from .settings import DATABASES
+
+DATABASES["default"]["TEST"] = {"NAME": "test.db"}
+```

--- a/wagtail_localize_rws_languagecloud/rws_client.py
+++ b/wagtail_localize_rws_languagecloud/rws_client.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 
 from time import sleep
 
@@ -93,10 +94,13 @@ class ApiClient:
         if not self.is_authenticated:
             raise NotAuthenticated()
 
+        # Ensure the name doesn't include special characters
+        cleaned_name = re.sub("[^A-Za-z0-9\\-\\_ ]+", "", name)
+
         source_language_code = rws_language_code(source_locale)
         body = json.dumps(
             {
-                "name": name,
+                "name": cleaned_name,
                 "dueBy": due_by,
                 "description": description,
                 "projectTemplate": {"id": template_id},

--- a/wagtail_localize_rws_languagecloud/rws_client.py
+++ b/wagtail_localize_rws_languagecloud/rws_client.py
@@ -9,6 +9,9 @@ import requests
 from django.conf import settings
 
 
+safe_characters = re.compile(r"[^\w\- ]+")
+
+
 def rws_language_code(language_code):
     """
     Returns the mapped RWS language code, if found in the LANGUAGE_CODE_MAP setting.
@@ -95,7 +98,7 @@ class ApiClient:
             raise NotAuthenticated()
 
         # Ensure the name doesn't include special characters
-        cleaned_name = re.sub("[^A-Za-z0-9\\-\\_ ]+", "", name)
+        cleaned_name = safe_characters.sub("", name)
 
         source_language_code = rws_language_code(source_locale)
         body = json.dumps(

--- a/wagtail_localize_rws_languagecloud/test/settings.py
+++ b/wagtail_localize_rws_languagecloud/test/settings.py
@@ -183,3 +183,11 @@ WAGTAILLOCALIZE_RWS_LANGUAGECLOUD = {}
 # we will set up the settings we need for each test case
 # using the @override_settings decorator
 SILENCED_SYSTEM_CHECKS = ["wagtail_localize_rws_languagecloud.E002"]
+
+# Import settings from local_settings.py file if it exists. Please use it to
+# keep settings that are not meant to be checked into Git and never check it
+# in.
+try:
+    from .local_settings import *  # noqa
+except ImportError:
+    pass


### PR DESCRIPTION
This PR adds handling for special characters for project names.

RWS LanguageCloud does not support having special characters in project names.

To fix this, I've updated the client to strip all special characters except `-` and `_` before sending to RWS LanguageCloud.