### PR TITLE
Fix: Handle invalid language cloud project statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Handle invalid language cloud project statuses
+
 ## [0.7] - 2022-03-01
 
 ### Added

--- a/wagtail_localize_rws_languagecloud/models.py
+++ b/wagtail_localize_rws_languagecloud/models.py
@@ -84,7 +84,10 @@ class LanguageCloudProject(StatusModel):
 
     @property
     def lc_project_status_label(self):
-        return LanguageCloudStatus(self.lc_project_status).label
+        if self.lc_project_status in LanguageCloudStatus:
+            return LanguageCloudStatus(self.lc_project_status).label
+
+        return self.lc_project_status
 
 
 class LanguageCloudFile(StatusModel):

--- a/wagtail_localize_rws_languagecloud/tests/test_models.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_models.py
@@ -170,3 +170,31 @@ class TestLanguageCloudProjectSettings(TestCase):
         )
         self.assertEqual(settings.source_language_code, "en")
         self.assertListEqual(settings.target_language_codes, ["fr"])
+
+
+class TestLanguageCloudProject(TestCase):
+    def test_lc_project_status_label(self):
+        _, source = create_test_page(
+            title="Test page",
+            slug="test-page",
+            test_charfield="Some test translatable content",
+        )
+
+        statuses = LanguageCloudStatus.choices
+
+        for value, label in statuses:
+            with self.subTest(value=value, label=label):
+                project = LanguageCloudProject(lc_project_status=value)
+
+                self.assertEqual(label, project.lc_project_status_label)
+
+    def test_lc_project_status_label_unknown_value(self):
+        _, source = create_test_page(
+            title="Test page",
+            slug="test-page",
+            test_charfield="Some test translatable content",
+        )
+
+        project = LanguageCloudProject(lc_project_status="some-unknown-value")
+
+        self.assertEqual("some-unknown-value", project.lc_project_status_label)


### PR DESCRIPTION
This PR fixes an issue where the report view returns an error if an unexpected value is set in `lc_project_status`.