### PR TITLE
Prevent syncing translated pages when there is an ongoing translation project

### DIFF
--- a/wagtail_localize_rws_languagecloud/templates/wagtail_localize_rws_languagecloud/admin/update_translations_override.html
+++ b/wagtail_localize_rws_languagecloud/templates/wagtail_localize_rws_languagecloud/admin/update_translations_override.html
@@ -11,7 +11,7 @@
       <div class="help-block help-info">
         <p><strong>{% trans "Translations for this page can't be updated right now" %}</strong></p>
         <p>
-          {% trans "LanguageCloud is currently translating this page. This means that translated pages cannot be synced at this time in order to avoid conflicts." %}
+          {% trans "This page is currently being translated on LanguageCloud. It cannot be synced at this time in order to avoid conflicts with existing translated pages." %}
         </p>
         <p>
           {% trans "Translated pages can be resynced as soon as all of the ongoing translations are completed." %}

--- a/wagtail_localize_rws_languagecloud/templates/wagtail_localize_rws_languagecloud/admin/update_translations_override.html
+++ b/wagtail_localize_rws_languagecloud/templates/wagtail_localize_rws_languagecloud/admin/update_translations_override.html
@@ -1,1 +1,23 @@
-<h1>Unable to update translations</h1>
+{% extends "wagtailadmin/base.html" %}
+
+{% load i18n %}
+
+{% block titletag %}{{ view.get_title }} {{ view.get_subtitle }}{% endblock %}
+
+{% block content %}
+    {% include "wagtailadmin/shared/header.html" with title=view.get_title subtitle=view.get_subtitle icon="doc-empty-inverse" %}
+
+    <div class="nice-padding">
+      <div class="help-block help-info">
+        <p><strong>{% trans "Translations for this page can't be updated right now" %}</strong></p>
+        <p>
+          {% trans "LanguageCloud is currently translating this page. This means that translated pages cannot be synced at this time in order to avoid conflicts." %}
+        </p>
+        <p>
+          {% trans "Translated pages can be resynced as soon as all of the ongoing translations are completed." %}
+        </p>
+      </div>
+
+      <a href="{{ back_url }}" class="button button-secondary">{% trans "Go back" %}</a>
+    </div>
+{% endblock content %}

--- a/wagtail_localize_rws_languagecloud/templates/wagtail_localize_rws_languagecloud/admin/update_translations_override.html
+++ b/wagtail_localize_rws_languagecloud/templates/wagtail_localize_rws_languagecloud/admin/update_translations_override.html
@@ -1,0 +1,1 @@
+<h1>Unable to update translations</h1>

--- a/wagtail_localize_rws_languagecloud/tests/test_views.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_views.py
@@ -86,7 +86,10 @@ class TestUpdateTranslationsOverride(TestCase):
 
                 # Response should be overridden by us
                 self.assertEqual(200, response.status_code)
-                self.assertContains(response, "Unable to update translations")
+                self.assertTemplateUsed(
+                    response,
+                    "wagtail_localize_rws_languagecloud/admin/update_translations_override.html",
+                )
 
     def test_should_allow_update_translations(self):
         statuses = [

--- a/wagtail_localize_rws_languagecloud/tests/test_views.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_views.py
@@ -1,0 +1,112 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+from django.utils import timezone
+from wagtail.core.models.i18n import Locale
+
+from wagtail_localize.models import Translation
+
+from ..models import LanguageCloudFile, LanguageCloudProject, LanguageCloudStatus
+from .helpers import create_editor_user, create_test_page
+
+
+@override_settings(
+    WAGTAILLOCALIZE_RWS_LANGUAGECLOUD={
+        "CLIENT_ID": "fakeid",
+        "CLIENT_SECRET": "fakesecret",
+        "ACCOUNT_ID": "fakeaccount",
+    },
+)
+class TestUpdateTranslationsOverride(TestCase):
+    def setUp(self):
+        self.locale_en = Locale.objects.get(language_code="en")
+        self.locale_fr = Locale.objects.create(language_code="fr")
+        self.locale_de = Locale.objects.create(language_code="de")
+        self.user = create_editor_user()
+        self.client.force_login(self.user)
+
+        # First make a page
+        self.page, self.source = create_test_page(
+            title="Test page",
+            slug="test-page",
+            test_charfield="Some test translatable content",
+        )
+
+        # Then translate it into the other languages
+        fr_translation = Translation.objects.create(
+            source=self.source,
+            target_locale=self.locale_fr,
+        )
+        fr_translation.save_target(publish=True)
+        de_translation = Translation.objects.create(
+            source=self.source,
+            target_locale=self.locale_de,
+        )
+        de_translation.save_target(publish=True)
+
+        # Simulate sending the translation to language cloud
+        self.project = LanguageCloudProject.objects.create(
+            translation_source=self.source,
+            source_last_updated_at=timezone.now(),
+            internal_status=LanguageCloudProject.STATUS_NEW,
+            lc_project_id="proj",
+        )
+
+        LanguageCloudFile.objects.create(
+            translation=fr_translation,
+            project=self.project,
+            lc_source_file_id="file_fr",
+            internal_status=LanguageCloudFile.STATUS_NEW,
+        )
+
+        LanguageCloudFile.objects.create(
+            translation=de_translation,
+            project=self.project,
+            lc_source_file_id="file_de",
+            internal_status=LanguageCloudFile.STATUS_NEW,
+        )
+
+    def test_should_show_unable_to_update_translations_message(self):
+        statuses = [
+            LanguageCloudStatus.CREATED,
+            LanguageCloudStatus.IN_PROGRESS,
+            "some-unknown-status",
+        ]
+
+        for status in statuses:
+            with self.subTest(lc_project_status=status):
+                self.project.lc_project_status = status
+                self.project.save()
+
+                response = self.client.get(
+                    reverse(
+                        "wagtail_localize:update_translations", args=[self.source.pk]
+                    )
+                )
+
+                # Response should be overridden by us
+                self.assertEqual(200, response.status_code)
+                self.assertContains(response, "Unable to update translations")
+
+    def test_should_allow_update_translations(self):
+        statuses = [
+            LanguageCloudStatus.COMPLETED,
+            LanguageCloudStatus.ARCHIVED,
+        ]
+
+        for status in statuses:
+            with self.subTest(lc_project_status=status):
+                self.project.lc_project_status = status
+                self.project.save()
+
+                response = self.client.get(
+                    reverse(
+                        "wagtail_localize:update_translations", args=[self.source.pk]
+                    )
+                )
+
+                # Check that the page is served by wagtail-localize
+                self.assertEqual(200, response.status_code)
+                self.assertTemplateUsed(
+                    response, "wagtail_localize/admin/update_translations.html"
+                )

--- a/wagtail_localize_rws_languagecloud/tests/test_views.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_views.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
-from wagtail.core.models.i18n import Locale
+from wagtail.core.models import Locale
 
 from wagtail_localize.models import Translation
 

--- a/wagtail_localize_rws_languagecloud/views.py
+++ b/wagtail_localize_rws_languagecloud/views.py
@@ -110,7 +110,7 @@ class UpdateTranslationsOverrideView(SingleObjectMixin, TemplateView):
         update the translations.
 
         This is to prevent conflicts between older and newer translations when
-        a translation is imported from LanguageCloud
+        a translation is imported from LanguageCloud.
         """
 
         self.object = self.get_object()

--- a/wagtail_localize_rws_languagecloud/wagtail_hooks.py
+++ b/wagtail_localize_rws_languagecloud/wagtail_hooks.py
@@ -7,7 +7,8 @@ from wagtail.core import hooks
 from wagtail.core.models import Locale, TranslatableMixin
 
 from wagtail_localize.models import TranslationSource
-from wagtail_localize_rws_languagecloud import views
+
+from . import views
 
 
 @hooks.register("register_admin_urls")
@@ -33,6 +34,17 @@ def register_admin_urls():
                 namespace="wagtail_localize_rws_languagecloud",
             ),
         )
+    ]
+
+
+@hooks.register("register_admin_urls")
+def override_wagtail_localize_urls():
+    return [
+        path(
+            "localize/update/<int:translation_source_id>/",
+            views.UpdateTranslationsOverrideView.as_view(),
+            name="update_translations",
+        ),
     ]
 
 


### PR DESCRIPTION
This PR will make it so that "Sync translated pages" returns an error message when the page being synced has an ongoing `LanguageCloudProject`.

This was done to prevent the situation where two competing `LanguageCloudProject`s are created for the same page, potentially causing conflicts.

"Ongoing" is defined as "not complete or not archived" based on the `lc_project_status` field. This definition includes "unknown" statuses. (e.g. an empty string)

**Screenshots**

![Screen Shot 2022-03-17 at 5 48 10 PM](https://user-images.githubusercontent.com/3102758/158783466-91cba0c9-dea9-4901-9433-eb4841d1988b.png)

