### PR TITLE
Strip out line sep characters when importing PO files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix an issue where a special line break character in PO files caused polib to
+  crash.
+
 ## [0.7.1] - 2022-03-16
 
 ### Fixed

--- a/wagtail_localize_rws_languagecloud/importer.py
+++ b/wagtail_localize_rws_languagecloud/importer.py
@@ -26,6 +26,10 @@ class Importer:
                 f"Expected PO file as string, received {target_file}"
             )
 
+        # Remove line sep (u2028) characters from the po string
+        # This is a workaround for a bug in polib.
+        target_file = target_file.replace("\u2028", "")
+
         warnings = translation.import_po(polib.pofile(target_file))
         for warning in warnings:
             if isinstance(warning, UnknownContext):

--- a/wagtail_localize_rws_languagecloud/tests/test_importer.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_importer.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 
 from unittest import mock
@@ -207,6 +208,27 @@ class TestImporter(TestCase):
         importer = Importer(file_mock, logging.getLogger("dummy"))
         with self.assertRaises(SuspiciousOperation):
             importer.import_po(self.translation, "/etc/passwd")
+
+    def test_importer_line_sep_char(self):
+        po_string = f"""#
+msgid ""
+msgstr ""
+"POT-Creation-Date: {datetime.datetime.utcnow()}\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+
+msgid "test_charfield"
+"Communicate on any channel  "
+"<br/>your customers prefer"
+msgstr ""
+"Kommunizieren Sie über die  <br/>bevorzugten Kanäle Ihrer Kundschaft"
+        """
+
+        file_mock = mock.Mock()
+        importer = Importer(file_mock, logging.getLogger("dummy"))
+
+        # This next line crashes without the fix
+        importer.import_po(self.translation, po_string)
 
 
 class TestImporterRichText(TestCase):


### PR DESCRIPTION
LanguageCloud sometimes returns line separator character in the PO file (not sure why it does). The character in question is this:

```
 
```

It’s invisible. Here’s more information about the character:

![Screen Shot 2022-03-23 at 1 22 28 PM](https://user-images.githubusercontent.com/3102758/159634572-5ae4457c-1965-4d8e-af03-9edffb4581c7.png)

[U+2028 Line separator](https://codepoints.net/U+2028?lang=en)

There’s a bug in `polib` where if we pass in a PO string (instead of a po filename) with this character, the parser incorrectly thinks it’s a new line, which in turn causes a syntax error.

I dug deeper and found that `polib` uses `po_string.splitlines()` to get an array of lines from the PO string. That method splits on the line sep character, which breaks the polib parser.

However, if the file was loaded by `polib` directly, it *is* able to parse it correctly. That’s because `for line in file_handler` correctly yields every line, and does not treat the line sep character as a new line.

The solution I implemented here is to strip out that specific special character before passing into polib. From what I can see from problematic po files, these characters often appear before a `<br>`, so stripping them out shouldn't affect the output as the `<br>` will render the line break.

```
text = text.replace("\u2028", "")
```