### PR TITLE
Fix: Strip out special characters in LanguageCloud file

### DIFF
--- a/wagtail_localize_rws_languagecloud/rws_client.py
+++ b/wagtail_localize_rws_languagecloud/rws_client.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import re
 
 from time import sleep
@@ -159,9 +160,19 @@ class ApiClient:
         if not self.is_authenticated:
             raise NotAuthenticated()
 
-        # Assume the last three characters are ".po"
-        filename_sans_suffix = filename[:-3]
-        cleaned_filename = safe_characters.sub("", filename_sans_suffix) + ".po"
+        # Clean the filename, leaving the file extension alone
+        filename_sans_ext = ""
+        parts = filename.split(os.extsep)
+        if len(parts) > 1:
+            ext = parts.pop()
+            filename_sans_ext = os.extsep.join(parts)
+        else:
+            ext = ""
+
+        # Strip out special characters from the filename
+        cleaned_filename = (
+            safe_characters.sub("", filename_sans_ext) + f"{os.extsep}{ext}"
+        )
 
         body = {
             "properties": json.dumps(

--- a/wagtail_localize_rws_languagecloud/rws_client.py
+++ b/wagtail_localize_rws_languagecloud/rws_client.py
@@ -159,10 +159,14 @@ class ApiClient:
         if not self.is_authenticated:
             raise NotAuthenticated()
 
+        # Assume the last three characters are ".po"
+        filename_sans_suffix = filename[:-3]
+        cleaned_filename = safe_characters.sub("", filename_sans_suffix) + ".po"
+
         body = {
             "properties": json.dumps(
                 {
-                    "name": filename,
+                    "name": cleaned_filename,
                     "role": "translatable",
                     "type": "native",
                     "language": rws_language_code(source_locale),
@@ -170,7 +174,7 @@ class ApiClient:
                 }
             )
         }
-        files = {"file": (filename, po_file, "text/plain")}
+        files = {"file": (cleaned_filename, po_file, "text/plain")}
         r = requests.post(
             f"{self.api_base}/projects/{project_id}/source-files",
             data=body,

--- a/wagtail_localize_rws_languagecloud/tests/test_rws_client.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_rws_client.py
@@ -289,6 +289,31 @@ class TestApiClient(TestCase):
         self.assertEqual(len(responses.calls), 1)
 
     @responses.activate
+    def test_create_source_file_with_special_characters(self):
+        responses.add(
+            responses.POST,
+            "https://lc-api.sdl.com/public-api/v1/projects/fakeproject/source-files",
+            json={"id": "123456"},
+            status=200,
+        )
+        client = ApiClient()
+
+        # fake the auth step
+        client.is_authenticated = True
+        client.headers = {}
+
+        resp = client.create_source_file(
+            "fakeproject", "fakepo", "fakefilename!@#.po", "en-US", "fr-CA"
+        )
+        self.assertEqual(len(responses.calls), 1)
+        request_body = responses.calls[0].request.body.decode("utf-8")
+        # Check that the filename is sent without special characters
+        # This assertion is kinda rudimentary, but it's otherwise difficult to
+        # parse raw form-data.
+        self.assertIn('{"name": "fakefilename.po"', request_body)
+        self.assertEqual(resp, {"id": "123456"})
+
+    @responses.activate
     def test_get_project_success(self):
         responses.add(
             responses.GET,


### PR DESCRIPTION
Follow up to #33, this time for the LanguageCloud source file.

Sending special characters in the filename doesn't raise errors, but the translation silently fails in LanguageCloud.

This PR will make it so that special characters are stripped out of the source file before uploading to LanguageCloud.