### PR TITLE
Add `update_translated_pages` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add new `update_translated_pages` management command
+
 ## [0.7.2] - 2022-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,6 +84,33 @@ This can be run on a regular basis using a scheduler like cron. We recommend an 
 - If using cron as a scheduler, [lockrun](http://unixwiz.net/tools/lockrun.html) can be used to prevent multiple instance of the same job running simultaneously.
 - If using a queue-based scheduler like Celery Beat, the `SyncManager` class contains `is_queued` and `is_running` extension points which could be used to implement a lock strategy.
 
+## Auto-sync translations
+
+Wagtail Localize gives you the option to sync the content of a source page to its corresponding translated pages (Sync translations). This is useful when the "source" page is updated and needs to be copied and re-translated.
+
+This plugin provides a management command that automatically runs sync translations on pages with stale translated content.
+
+```
+./manage.py update_translated_pages
+```
+
+This command:
+
+- Runs "sync translations" on pages that have been published but not yet synced.
+- Queues these pages to be translated on LanguageCloud.
+- Sends an email summary with the list of pages that were synced or skipped.
+
+Pages that match the following criteria are excluded from auto-syncing:
+
+- Pages that haven't been translated.
+- Pages that have pending translations on RWS LanguageCloud.
+
+You can safely preview which pages will be affected by this management command by running it with `--dry-run`:
+
+```
+./manage.py update_translated_pages --dry-run
+```
+
 ## Signals
 
 `translation_imported`

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This can be run on a regular basis using a scheduler like cron. We recommend an 
 
 ## Auto-sync translations
 
-Wagtail Localize gives you the option to sync the content of a source page to its corresponding translated pages (Sync translations). This is useful when the "source" page is updated and needs to be copied and re-translated.
+Wagtail Localize gives you the option to sync the content of a source page to its corresponding translated pages (Sync translations). This is useful when the source page is updated and needs to be copied and re-translated.
 
 This plugin provides a management command that automatically runs sync translations on pages with stale translated content.
 
@@ -105,7 +105,7 @@ Pages that match the following criteria are excluded from auto-syncing:
 - Pages that haven't been translated.
 - Pages that have pending translations on RWS LanguageCloud.
 
-You can safely preview which pages will be affected by this management command by running it with `--dry-run`:
+You can safely preview which pages will be affected by this management command by running it with `--dry-run`.
 
 ```
 ./manage.py update_translated_pages --dry-run

--- a/README.md
+++ b/README.md
@@ -70,16 +70,22 @@ This allows users of [RWS LanguageCloud](https://www.rws.com/translation/languag
    ./manage.py migrate
    ```
 
-## Synchronisation
+## Exporting and importing content to/from LanguageCloud
 
-This plugin uses a background job to:
+This plugin works by:
 
-- Identify text in wagtail which is pending localization and export it to LanguageCloud
-- Identify completed projects in LanguageCloud and import the localized content back into Wagtail
+- Identifying text in Wagtail which is pending localization and exporting it to LanguageCloud
+- Identifying completed projects in LanguageCloud and importing the localized content back into Wagtail
 
-This is done using a management command `./manage.py sync_rws`.
+This is done through a management command:
 
-This should be run on a regular basis using a scheduler like cron. We recommend an interval of about every 10 minutes. It is desirable to prevent more than one copy of the sync command from running at the same time.
+```
+./manage.py sync_rws
+```
+
+This command needs to be run on an interval using a scheduler like cron. We recommend an interval of about every 10 minutes.
+
+It is desirable to prevent more than one copy of the sync command from running at the same time.
 
 - If using cron as a scheduler, [lockrun](http://unixwiz.net/tools/lockrun.html) can be used to prevent multiple instance of the same job running simultaneously.
 - If using a queue-based scheduler like Celery Beat, the `SyncManager` class contains `is_queued` and `is_running` extension points which could be used to implement a lock strategy.

--- a/README.md
+++ b/README.md
@@ -79,16 +79,16 @@ This plugin uses a background job to:
 
 This is done using a management command `./manage.py sync_rws`.
 
-This can be run on a regular basis using a scheduler like cron. We recommend an interval of about every 10 minutes. It is desirable to prevent more than one copy of the sync command from running at the same time.
+This should be run on a regular basis using a scheduler like cron. We recommend an interval of about every 10 minutes. It is desirable to prevent more than one copy of the sync command from running at the same time.
 
 - If using cron as a scheduler, [lockrun](http://unixwiz.net/tools/lockrun.html) can be used to prevent multiple instance of the same job running simultaneously.
 - If using a queue-based scheduler like Celery Beat, the `SyncManager` class contains `is_queued` and `is_running` extension points which could be used to implement a lock strategy.
 
-## Auto-sync translations
+## Update translated pages
 
-Wagtail Localize gives you the option to sync the content of a source page to its corresponding translated pages (Sync translations). This is useful when the source page is updated and needs to be copied and re-translated.
+Wagtail Localize comes with a feature called "Sync translated pages" which copies untranslated content from the source page to its translated pages. This is useful when the source page content has been updated and needs to be copied and re-translated.
 
-This plugin provides a management command that automatically runs sync translations on pages with stale translated content.
+This plugin comes with an optional management command that automates this process by running sync translated pages on pages with stale translated content.
 
 ```
 ./manage.py update_translated_pages
@@ -96,19 +96,22 @@ This plugin provides a management command that automatically runs sync translati
 
 This command:
 
-- Runs "sync translations" on pages that have been published but not yet synced.
-- Queues these pages to be translated on LanguageCloud.
+- Runs "sync translated pages" on pages that have been published but not yet synced.
+- Queues these pages to be translated on LanguageCloud using the default settings.
 - Sends an email summary with the list of pages that were synced or skipped.
 
 Pages that match the following criteria are excluded from auto-syncing:
 
-- Pages that haven't been translated.
-- Pages that have pending translations on RWS LanguageCloud.
+- Pages that haven't been translated before.
+- Pages that have pending translations on LanguageCloud.
 
-You can safely preview which pages will be affected by this management command by running it with `--dry-run`.
+You can use this command ad-hoc, or schedule it to run on an interval to automatically keep translated versions of your content up-to-date.
+
+You can safely preview which pages will be affected without actually updating them by running the command with `--dry-run`.
 
 ```
 ./manage.py update_translated_pages --dry-run
+
 ```
 
 ## Signals

--- a/wagtail_localize_rws_languagecloud/emails.py
+++ b/wagtail_localize_rws_languagecloud/emails.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.template import Context, Template
 from django.utils.translation import gettext_lazy
 from wagtail.admin.mail import send_mail
 
@@ -13,22 +14,72 @@ def get_full_url(url):
     return url
 
 
-def send_emails(translation):
-    subject, body = compose_email(translation)
+# sync_rws command emails
+def send_sync_rws_emails(translation):
+    subject, body = compose_sync_rws_email(translation)
     recipients = get_recipients()
     for recipient in recipients:
         send_mail(subject, body, [recipient])
 
 
-def compose_email(translation):
+def compose_sync_rws_email(translation):
     subject = gettext_lazy("Translated content ready for review")
     body = gettext_lazy(
         "Translated content for '%(instance)s' is ready for review at: %(edit_url)s"
-        % {
-            "instance": str(translation.get_target_instance()),
-            "edit_url": get_full_url(translation.get_target_instance_edit_url()),
+    ) % {
+        "instance": str(translation.get_target_instance()),
+        "edit_url": get_full_url(translation.get_target_instance_edit_url()),
+    }
+    return subject, body
+
+
+# update_translated_pages emails
+def send_update_translated_pages_emails(all_pages, updated_pages, skipped_pages):
+    """Notifies users that translated pages have been synced.
+
+    Args:
+        all_pages (List[Tuple[int, str]]): List of all pages considered.
+        updated_pages (List[Tuple[int, str]]): List of updated pages.
+        skipped_pages (List[Tuple[int, str]]): List of pages that were not updated.
+    """
+    subject, body = compose_update_translated_pages_email(
+        all_pages, updated_pages, skipped_pages
+    )
+    recipients = get_recipients()
+    for recipient in recipients:
+        send_mail(subject, body, [recipient])
+
+
+UPDATE_TRANSLATED_PAGES_EMAIL_TEMPLATE = Template(
+    """{% load i18n %}
+{% blocktrans with total_count=all_pages|length updated_count=updated_pages|length skipped_count=skipped_pages|length %}
+Found {{ total_count }} page(s) with stale translations, of which {{ updated_count }} were synced and {{ skipped_count }} were skipped.{% endblocktrans %}
+
+{% trans "Pages that were synced:" %}
+
+{% for page_pk, page_title in updated_pages %}{{ forloop.counter }}. {{ page_title }}: {% url 'wagtailadmin_pages:edit' page_pk %}{% empty %}-{% endfor %}
+
+{% trans "Pages that were skipped because they had pending translations on RWS LanguageCloud:" %}
+
+{% for page_pk, page_title in skipped_pages %}{{ forloop.counter }}. {{ page_title }}: {{ base_url }}{% url 'wagtailadmin_pages:edit' page_pk %}{% empty %}-{% endfor %}
+"""
+)
+
+
+def compose_update_translated_pages_email(all_pages, updated_pages, skipped_pages):
+    subject = gettext_lazy("Translated pages have been synced")
+
+    context = Context(
+        {
+            "all_pages": all_pages,
+            "updated_pages": updated_pages,
+            "skipped_pages": skipped_pages,
+            "base_url": getattr(settings, "BASE_URL", ""),
         }
     )
+
+    body = UPDATE_TRANSLATED_PAGES_EMAIL_TEMPLATE.render(context)
+
     return subject, body
 
 

--- a/wagtail_localize_rws_languagecloud/emails.py
+++ b/wagtail_localize_rws_languagecloud/emails.py
@@ -57,7 +57,8 @@ Found {{ total_count }} page(s) with stale translations, of which {{ updated_cou
 
 {% trans "Pages that were synced:" %}
 
-{% for page_pk, page_title in updated_pages %}{{ forloop.counter }}. {{ page_title }}: {% url 'wagtailadmin_pages:edit' page_pk %}{% empty %}-{% endfor %}
+{% for page_pk, page_title in updated_pages %}{{ forloop.counter }}. {{ page_title }}: {% url 'wagtailadmin_pages:edit' page_pk %}{% empty %}-
+{% endfor %}
 
 {% trans "Pages that were skipped because they had pending translations on RWS LanguageCloud:" %}
 

--- a/wagtail_localize_rws_languagecloud/forms.py
+++ b/wagtail_localize_rws_languagecloud/forms.py
@@ -68,10 +68,10 @@ class LanguageCloudProjectSettingsForm(WagtailAdminModelForm):
             "The project name will be a combination of the "
             "supplied prefix and the source title. e.g. '%(name)s'"
             % {
-                "name": f"{self.default_project_name_prefix}{self._get_source_name(source_object_instance)}"
+                "name": f"{get_default_project_name_prefix()}{self._get_source_name(source_object_instance)}"
             }
         )
-        self.fields["name"].initial = self.default_project_name_prefix
+        self.fields["name"].initial = get_default_project_name_prefix()
         self.fields["description"].initial = self._get_default_project_description(
             source_object_instance, user=user
         )
@@ -84,11 +84,6 @@ class LanguageCloudProjectSettingsForm(WagtailAdminModelForm):
             initial=get_default_project_template_id(),
             widget=forms.Select(),
         )
-
-    @classproperty
-    def default_project_name_prefix(self):
-        prefix = settings.WAGTAILLOCALIZE_RWS_LANGUAGECLOUD.get("PROJECT_PREFIX", "")
-        return f"{prefix}{timezone.now():%Y-%m-%d}_"
 
     @classproperty
     def default_due_date(self):

--- a/wagtail_localize_rws_languagecloud/forms.py
+++ b/wagtail_localize_rws_languagecloud/forms.py
@@ -19,6 +19,25 @@ from wagtail_localize_rws_languagecloud.rws_client import ApiClient, NotAuthenti
 logger = logging.getLogger(__name__)
 
 
+# Initial values for the form
+# These are split out because they are also used elsewhere
+def get_default_project_template_id():
+    return settings.WAGTAILLOCALIZE_RWS_LANGUAGECLOUD.get("TEMPLATE_ID")
+
+
+def get_default_project_name_prefix():
+    prefix = settings.WAGTAILLOCALIZE_RWS_LANGUAGECLOUD.get("PROJECT_PREFIX", "")
+    return f"{prefix}{timezone.now():%Y-%m-%d}_"
+
+
+def get_default_due_date():
+    now = timezone.now()
+    delta = settings.WAGTAILLOCALIZE_RWS_LANGUAGECLOUD.get(
+        "DUE_BY_DELTA", datetime.timedelta(days=7)
+    )
+    return now + delta
+
+
 class LanguageCloudProjectSettingsForm(WagtailAdminModelForm):
     class Meta:
         exclude = (
@@ -41,6 +60,7 @@ class LanguageCloudProjectSettingsForm(WagtailAdminModelForm):
         super().__init__(data, files, instance=instance, prefix=prefix, **kwargs)
 
         self.fields["user"].initial = user
+
         self.fields["user"].widget = forms.HiddenInput()
 
         self.fields["name"].label = _("Name prefix")
@@ -61,13 +81,9 @@ class LanguageCloudProjectSettingsForm(WagtailAdminModelForm):
         self.fields["template_id"] = forms.ChoiceField(
             label=_("Template"),
             choices=self._get_project_template_choices(),
-            initial=self.default_project_template_id,
+            initial=get_default_project_template_id(),
             widget=forms.Select(),
         )
-
-    @classproperty
-    def default_project_template_id(self):
-        return settings.WAGTAILLOCALIZE_RWS_LANGUAGECLOUD.get("TEMPLATE_ID")
 
     @classproperty
     def default_project_name_prefix(self):
@@ -139,4 +155,4 @@ class LanguageCloudProjectSettingsForm(WagtailAdminModelForm):
                 for template in project_templates["items"]
             ]
 
-        return [(self.default_project_template_id, _("Default template"))]
+        return [(get_default_project_template_id(), _("Default template"))]

--- a/wagtail_localize_rws_languagecloud/forms.py
+++ b/wagtail_localize_rws_languagecloud/forms.py
@@ -4,7 +4,6 @@ import logging
 from django import forms
 from django.conf import settings
 from django.utils import timezone
-from django.utils.functional import classproperty
 from django.utils.translation import gettext as _
 from requests import RequestException
 from wagtail.admin.forms import WagtailAdminModelForm
@@ -76,7 +75,7 @@ class LanguageCloudProjectSettingsForm(WagtailAdminModelForm):
             source_object_instance, user=user
         )
         self.fields["description"].widget = forms.Textarea(attrs={"rows": 3})
-        self.fields["due_date"].initial = self.default_due_date
+        self.fields["due_date"].initial = get_default_due_date()
 
         self.fields["template_id"] = forms.ChoiceField(
             label=_("Template"),
@@ -84,14 +83,6 @@ class LanguageCloudProjectSettingsForm(WagtailAdminModelForm):
             initial=get_default_project_template_id(),
             widget=forms.Select(),
         )
-
-    @classproperty
-    def default_due_date(self):
-        now = timezone.now()
-        delta = settings.WAGTAILLOCALIZE_RWS_LANGUAGECLOUD.get(
-            "DUE_BY_DELTA", datetime.timedelta(days=7)
-        )
-        return now + delta
 
     def clean_due_date(self):
         due_date = self.cleaned_data["due_date"]

--- a/wagtail_localize_rws_languagecloud/forms.py
+++ b/wagtail_localize_rws_languagecloud/forms.py
@@ -4,6 +4,7 @@ import logging
 from django import forms
 from django.conf import settings
 from django.utils import timezone
+from django.utils.functional import classproperty
 from django.utils.translation import gettext as _
 from requests import RequestException
 from wagtail.admin.forms import WagtailAdminModelForm
@@ -64,16 +65,16 @@ class LanguageCloudProjectSettingsForm(WagtailAdminModelForm):
             widget=forms.Select(),
         )
 
-    @property
+    @classproperty
     def default_project_template_id(self):
         return settings.WAGTAILLOCALIZE_RWS_LANGUAGECLOUD.get("TEMPLATE_ID")
 
-    @property
+    @classproperty
     def default_project_name_prefix(self):
         prefix = settings.WAGTAILLOCALIZE_RWS_LANGUAGECLOUD.get("PROJECT_PREFIX", "")
         return f"{prefix}{timezone.now():%Y-%m-%d}_"
 
-    @property
+    @classproperty
     def default_due_date(self):
         now = timezone.now()
         delta = settings.WAGTAILLOCALIZE_RWS_LANGUAGECLOUD.get(

--- a/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
@@ -6,6 +6,9 @@ from django.db.models.query_utils import Q
 from wagtail.core.models import Page
 
 from wagtail_localize.models import TranslationSource
+from wagtail_localize_rws_languagecloud.emails import (
+    send_update_translated_pages_emails,
+)
 from wagtail_localize_rws_languagecloud.forms import LanguageCloudProjectSettingsForm
 from wagtail_localize_rws_languagecloud.models import (
     LanguageCloudProjectSettings,
@@ -45,18 +48,18 @@ class Command(BaseCommand):
         pages = Page.objects.filter(
             translation_key=OuterRef("object_id"), locale_id=OuterRef("locale_id")
         )
-        sources = TranslationSource.objects.annotate(
+        all_sources = TranslationSource.objects.annotate(
             last_published_at=Subquery(pages.values("last_published_at")[:1]),
+            page_pk=Subquery(pages.values("id")[:1]),
             page_title=Subquery(pages.values("title")[:1]),
         ).filter(
             # Only sources for live pages
-            Q(
-                object_id__in=Page.objects.live().values_list(
-                    "translation_key", flat=True
-                )
-            ),
+            object_id__in=Page.objects.live().values_list("translation_key", flat=True),
             # Only pages that have been published after the last sync
-            Q(last_updated_at__lt=F("last_published_at")),
+            last_updated_at__lt=F("last_published_at"),
+        )
+
+        sources_to_update = all_sources.filter(
             # Only pages without ongoing translation projects,
             Q(languagecloudproject__isnull=True)
             | Q(
@@ -67,9 +70,21 @@ class Command(BaseCommand):
             ),
         )
 
-        logger.info(f"Found {len(sources)} page(s) to update.")
+        total_count = len(all_sources)
+        to_update_count = len(sources_to_update)
 
-        for source in sources:
+        logger.info(
+            f"Found {total_count} recently updated page(s).\n"
+            f"       {total_count - to_update_count} will be skipped.\n"
+            f"       {to_update_count} will be synced."
+            ""
+        )
+
+        all_pages = {(source.page_pk, source.page_title) for source in all_sources}
+
+        updated_pages = set()
+
+        for source in sources_to_update:
             if options["dry_run"]:
                 logger.info(f"Would update translations for page: {source.page_title}")
                 continue
@@ -93,5 +108,16 @@ class Command(BaseCommand):
                 due_date=LanguageCloudProjectSettingsForm.default_due_date,
                 template_id=LanguageCloudProjectSettingsForm.default_project_template_id,
             )
+
+            updated_pages.add((source.page_pk, source.page_title))
+
+        skipped_pages = all_pages - updated_pages
+
+        for _, page_title in skipped_pages:
+            logger.debug(f"Skipped page: {page_title}")
+
+        send_update_translated_pages_emails(
+            list(all_pages), list(updated_pages), list(skipped_pages)
+        )
 
         logger.info("...Done")

--- a/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
@@ -112,6 +112,8 @@ class Command(BaseCommand):
                 translation_source=source,
                 translations=enabled_translations,
                 name=get_default_project_name_prefix(),
+                # Prefix with "Wagtail" because we don't have a user to
+                # pass into get_default_project_description.
                 description="Wagtail\n" + get_default_project_description(source),
                 due_date=get_default_due_date(),
                 template_id=get_default_project_template_id(),

--- a/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from django.db.models.expressions import F, OuterRef, Subquery
 from django.db.models.query_utils import Q
 from wagtail.core.models import Page
@@ -28,6 +29,7 @@ class Command(BaseCommand):
             help="Don't actually send the pages to RWS LanguageCloud",
         )
 
+    @transaction.atomic
     def handle(self, *args, **options):
         # Set up logging
         log_level = logging.INFO

--- a/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
@@ -12,6 +12,7 @@ from wagtail_localize_rws_languagecloud.emails import (
 )
 from wagtail_localize_rws_languagecloud.forms import (
     LanguageCloudProjectSettingsForm,
+    get_default_due_date,
     get_default_project_name_prefix,
     get_default_project_template_id,
 )
@@ -115,7 +116,7 @@ class Command(BaseCommand):
                 + LanguageCloudProjectSettingsForm._get_default_project_description(
                     None, source
                 ),
-                due_date=LanguageCloudProjectSettingsForm.default_due_date,
+                due_date=get_default_due_date(),
                 template_id=get_default_project_template_id(),
             )
 

--- a/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
@@ -72,9 +72,9 @@ class Command(BaseCommand):
         to_update_count = len(sources_to_update)
 
         logger.info(
-            f"Found {total_count} pages with stale translated content.\n"
-            f"       {total_count - to_update_count} will be skipped.\n"
-            f"       {to_update_count} will be synced."
+            f"Found {total_count} page(s) with stale translated content.\n"
+            f"       {to_update_count} will be synced.\n"
+            f"       {total_count - to_update_count} will be skipped."
         )
 
         all_pages = {(source.page_pk, source.page_title) for source in all_sources}
@@ -82,6 +82,8 @@ class Command(BaseCommand):
         updated_pages = set()
 
         for index, source in enumerate(sources_to_update):
+            updated_pages.add((source.page_pk, source.page_title))
+
             counter = f"[{index + 1}/{to_update_count}]"
 
             if options["dry_run"]:
@@ -111,8 +113,6 @@ class Command(BaseCommand):
                 due_date=LanguageCloudProjectSettingsForm.default_due_date,
                 template_id=LanguageCloudProjectSettingsForm.default_project_template_id,
             )
-
-            updated_pages.add((source.page_pk, source.page_title))
 
         skipped_pages = all_pages - updated_pages
 

--- a/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
@@ -10,7 +10,10 @@ from wagtail_localize.models import TranslationSource
 from wagtail_localize_rws_languagecloud.emails import (
     send_update_translated_pages_emails,
 )
-from wagtail_localize_rws_languagecloud.forms import LanguageCloudProjectSettingsForm
+from wagtail_localize_rws_languagecloud.forms import (
+    LanguageCloudProjectSettingsForm,
+    get_default_project_template_id,
+)
 from wagtail_localize_rws_languagecloud.models import (
     LanguageCloudProjectSettings,
     LanguageCloudStatus,
@@ -112,7 +115,7 @@ class Command(BaseCommand):
                     None, source
                 ),
                 due_date=LanguageCloudProjectSettingsForm.default_due_date,
-                template_id=LanguageCloudProjectSettingsForm.default_project_template_id,
+                template_id=get_default_project_template_id(),
             )
 
         skipped_pages = all_pages - updated_pages

--- a/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
@@ -12,6 +12,7 @@ from wagtail_localize_rws_languagecloud.emails import (
 )
 from wagtail_localize_rws_languagecloud.forms import (
     LanguageCloudProjectSettingsForm,
+    get_default_project_name_prefix,
     get_default_project_template_id,
 )
 from wagtail_localize_rws_languagecloud.models import (
@@ -109,7 +110,7 @@ class Command(BaseCommand):
             LanguageCloudProjectSettings.get_or_create_from_source_and_translation_data(
                 translation_source=source,
                 translations=enabled_translations,
-                name=LanguageCloudProjectSettingsForm.default_project_name_prefix,
+                name=get_default_project_name_prefix(),
                 description="Wagtail\n"
                 + LanguageCloudProjectSettingsForm._get_default_project_description(
                     None, source

--- a/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
@@ -11,8 +11,8 @@ from wagtail_localize_rws_languagecloud.emails import (
     send_update_translated_pages_emails,
 )
 from wagtail_localize_rws_languagecloud.forms import (
-    LanguageCloudProjectSettingsForm,
     get_default_due_date,
+    get_default_project_description,
     get_default_project_name_prefix,
     get_default_project_template_id,
 )
@@ -112,10 +112,7 @@ class Command(BaseCommand):
                 translation_source=source,
                 translations=enabled_translations,
                 name=get_default_project_name_prefix(),
-                description="Wagtail\n"
-                + LanguageCloudProjectSettingsForm._get_default_project_description(
-                    None, source
-                ),
+                description="Wagtail\n" + get_default_project_description(source),
                 due_date=get_default_due_date(),
                 template_id=get_default_project_template_id(),
             )

--- a/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.db.models.expressions import F, OuterRef, Subquery
@@ -119,7 +120,10 @@ class Command(BaseCommand):
         for page_pk, page_title in skipped_pages:
             logger.debug(f'Skipped page: {page_pk} - "{page_title}"')
 
-        if not options["dry_run"]:
+        if (
+            settings.WAGTAILLOCALIZE_RWS_LANGUAGECLOUD.get("SEND_EMAILS", False)
+            and not options["dry_run"]
+        ):
             logger.info("Sending summary emails")
             send_update_translated_pages_emails(
                 list(all_pages), list(updated_pages), list(skipped_pages)

--- a/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/management/commands/update_translated_pages.py
@@ -1,0 +1,97 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db.models.expressions import F, OuterRef, Subquery
+from django.db.models.query_utils import Q
+from wagtail.core.models import Page
+
+from wagtail_localize.models import TranslationSource
+from wagtail_localize_rws_languagecloud.forms import LanguageCloudProjectSettingsForm
+from wagtail_localize_rws_languagecloud.models import (
+    LanguageCloudProjectSettings,
+    LanguageCloudStatus,
+)
+
+
+class Command(BaseCommand):
+    help = "Update translations of recently published pages and send them to RWS LanguageCloud"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="Don't actually send the pages to RWS LanguageCloud",
+        )
+
+    def handle(self, *args, **options):
+        # Set up logging
+        log_level = logging.INFO
+        if options["verbosity"] > 1:
+            log_level = logging.DEBUG
+
+        logger = logging.getLogger(__name__)
+
+        console = logging.StreamHandler()
+        console.setLevel(log_level)
+        console.setFormatter(logging.Formatter("%(levelname)s - %(message)s"))
+        logger.addHandler(console)
+        logger.setLevel(log_level)
+
+        logger.info("Updating translations of recently published pages...")
+
+        # Get all pages that have been published _after_ the translation source was synced.
+        pages = Page.objects.filter(
+            translation_key=OuterRef("object_id"), locale_id=OuterRef("locale_id")
+        )
+        sources = TranslationSource.objects.annotate(
+            last_published_at=Subquery(pages.values("last_published_at")[:1]),
+            page_title=Subquery(pages.values("title")[:1]),
+        ).filter(
+            # Only sources for live pages
+            Q(
+                object_id__in=Page.objects.live().values_list(
+                    "translation_key", flat=True
+                )
+            ),
+            # Only pages that have been published after the last sync
+            Q(last_updated_at__lt=F("last_published_at")),
+            # Only pages without ongoing translation projects,
+            Q(languagecloudproject__isnull=True)
+            | Q(
+                languagecloudproject__lc_project_status__in=[
+                    LanguageCloudStatus.COMPLETED,
+                    LanguageCloudStatus.ARCHIVED,
+                ]
+            ),
+        )
+
+        logger.info(f"Found {len(sources)} page(s) to update.")
+
+        for source in sources:
+            if options["dry_run"]:
+                logger.info(f"Would update translations for page: {source.page_title}")
+                continue
+
+            logger.info(f"Updating translations for page: {source.page_title}")
+
+            # Sync content to translated pages
+            source.update_from_db()
+
+            enabled_translations = source.translations.filter(enabled=True)
+
+            # Prep for sending to RWS LanguageCloud
+            LanguageCloudProjectSettings.get_or_create_from_source_and_translation_data(
+                translation_source=source,
+                translations=enabled_translations,
+                name=LanguageCloudProjectSettingsForm.default_project_name_prefix,
+                description="Wagtail\n"
+                + LanguageCloudProjectSettingsForm._get_default_project_description(
+                    None, source
+                ),
+                due_date=LanguageCloudProjectSettingsForm.default_due_date,
+                template_id=LanguageCloudProjectSettingsForm.default_project_template_id,
+            )
+
+        logger.info("...Done")

--- a/wagtail_localize_rws_languagecloud/sync.py
+++ b/wagtail_localize_rws_languagecloud/sync.py
@@ -7,7 +7,7 @@ from django.db import transaction
 from django.db.models import Count, F, Q
 from requests.exceptions import RequestException
 
-from .emails import send_emails
+from .emails import send_sync_rws_emails
 from .importer import Importer
 from .models import (
     LanguageCloudFile,
@@ -336,7 +336,7 @@ def _import(client, logger):
                     if settings.WAGTAILLOCALIZE_RWS_LANGUAGECLOUD.get(
                         "SEND_EMAILS", False
                     ):
-                        send_emails(db_source_file.translation)
+                        send_sync_rws_emails(db_source_file.translation)
 
                     translation_imported.send(
                         sender=LanguageCloudProject,

--- a/wagtail_localize_rws_languagecloud/templates/wagtail_localize_rws_languagecloud/emails/update_translated_pages.txt
+++ b/wagtail_localize_rws_languagecloud/templates/wagtail_localize_rws_languagecloud/emails/update_translated_pages.txt
@@ -1,0 +1,11 @@
+{% load i18n %}{% blocktrans with total_count=all_pages|length updated_count=updated_pages|length skipped_count=skipped_pages|length %}
+Found {{ total_count }} page(s) with stale translations, of which {{ updated_count }} were synced and {{ skipped_count }} were skipped.{% endblocktrans %}
+
+{% trans "Pages that were synced:" %}
+
+{% for page_pk, page_title in updated_pages %}{{ forloop.counter }}. {{ page_title }}: {% url 'wagtailadmin_pages:edit' page_pk %}{% empty %}-
+{% endfor %}
+
+{% trans "Pages that were skipped because they had pending translations on RWS LanguageCloud:" %}
+
+{% for page_pk, page_title in skipped_pages %}{{ forloop.counter }}. {{ page_title }}: {{ base_url }}{% url 'wagtailadmin_pages:edit' page_pk %}{% empty %}-{% endfor %}

--- a/wagtail_localize_rws_languagecloud/tests/test_emails.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_emails.py
@@ -90,12 +90,12 @@ class TestEmails(TestCase):
 
     @mock.patch("wagtail_localize_rws_languagecloud.emails.send_mail")
     def test_send_email(self, send_mail):
-        emails.send_emails(self.translation)
+        emails.send_sync_rws_emails(self.translation)
         self.assertEqual(send_mail.call_count, 2)
 
     @override_settings(BASE_URL="https://foobar.com")
     def test_compose_email(self):
-        _, body = emails.compose_email(self.translation)
+        _, body = emails.compose_sync_rws_email(self.translation)
         self.assertIn(
             "https://foobar.com" + self.translation.get_target_instance_edit_url(), body
         )

--- a/wagtail_localize_rws_languagecloud/tests/test_forms.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_forms.py
@@ -13,6 +13,7 @@ from wagtail.tests.utils import WagtailTestUtils
 
 from wagtail_localize_rws_languagecloud.forms import (
     LanguageCloudProjectSettingsForm,
+    get_default_due_date,
     get_default_project_name_prefix,
     get_default_project_template_id,
 )
@@ -71,7 +72,7 @@ class TestProjectSettingsForm(TestCase, WagtailTestUtils):
 
     def test_get_project_due_date_without_custom_delta(self):
         self.assertEqual(
-            self.form.default_due_date,
+            get_default_due_date(),
             datetime.datetime(2018, 2, 9, 12, 0, 1, tzinfo=pytz.utc),
         )
 
@@ -80,7 +81,7 @@ class TestProjectSettingsForm(TestCase, WagtailTestUtils):
     )
     def test_get_project_due_date_with_custom_delta(self):
         self.assertEqual(
-            self.form.default_due_date,
+            get_default_due_date(),
             datetime.datetime(2018, 2, 16, 12, 0, 1, tzinfo=pytz.utc),
         )
 

--- a/wagtail_localize_rws_languagecloud/tests/test_forms.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_forms.py
@@ -13,6 +13,7 @@ from wagtail.tests.utils import WagtailTestUtils
 
 from wagtail_localize_rws_languagecloud.forms import (
     LanguageCloudProjectSettingsForm,
+    get_default_project_name_prefix,
     get_default_project_template_id,
 )
 from wagtail_localize_rws_languagecloud.models import LanguageCloudProjectSettings
@@ -55,7 +56,7 @@ class TestProjectSettingsForm(TestCase, WagtailTestUtils):
 
     def test_get_project_name_without_custom_prefix(self):
         self.assertEqual(
-            self.form.default_project_name_prefix,
+            get_default_project_name_prefix(),
             "2018-02-02_",
         )
 
@@ -64,7 +65,7 @@ class TestProjectSettingsForm(TestCase, WagtailTestUtils):
     )
     def test_get_project_name_with_custom_prefix(self):
         self.assertEqual(
-            self.form.default_project_name_prefix,
+            get_default_project_name_prefix(),
             "Website_2018-02-02_",
         )
 

--- a/wagtail_localize_rws_languagecloud/tests/test_forms.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_forms.py
@@ -11,7 +11,10 @@ from freezegun import freeze_time
 from wagtail.admin.edit_handlers import get_form_for_model
 from wagtail.tests.utils import WagtailTestUtils
 
-from wagtail_localize_rws_languagecloud.forms import LanguageCloudProjectSettingsForm
+from wagtail_localize_rws_languagecloud.forms import (
+    LanguageCloudProjectSettingsForm,
+    get_default_project_template_id,
+)
 from wagtail_localize_rws_languagecloud.models import LanguageCloudProjectSettings
 
 from .helpers import create_test_page
@@ -101,7 +104,7 @@ class TestProjectSettingsForm(TestCase, WagtailTestUtils):
         )
 
     def test_get_default_project_template(self):
-        self.assertEqual(self.form.default_project_template_id, "c0ffee")
+        self.assertEqual(get_default_project_template_id(), "c0ffee")
 
     def test_user_field_is_hidden(self):
         self.assertIsInstance(self.form.fields["user"].widget, forms.HiddenInput)

--- a/wagtail_localize_rws_languagecloud/tests/test_forms.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_forms.py
@@ -14,6 +14,7 @@ from wagtail.tests.utils import WagtailTestUtils
 from wagtail_localize_rws_languagecloud.forms import (
     LanguageCloudProjectSettingsForm,
     get_default_due_date,
+    get_default_project_description,
     get_default_project_name_prefix,
     get_default_project_template_id,
 )
@@ -87,7 +88,7 @@ class TestProjectSettingsForm(TestCase, WagtailTestUtils):
 
     def test_get_default_project_description(self):
         self.assertEqual(
-            self.form._get_default_project_description(self.test_page),
+            get_default_project_description(self.test_page),
             self.test_page.full_url,
         )
 
@@ -95,14 +96,14 @@ class TestProjectSettingsForm(TestCase, WagtailTestUtils):
         user = self.create_test_user()
         self.assertIn(
             "test@email.com",
-            self.form._get_default_project_description(self.test_page, user=user),
+            get_default_project_description(self.test_page, user=user),
         )
         user.first_name = "John"
         user.last_name = "Doe"
         user.save()
         self.assertIn(
             "John Doe",
-            self.form._get_default_project_description(self.test_page, user=user),
+            get_default_project_description(self.test_page, user=user),
         )
 
     def test_get_default_project_template(self):

--- a/wagtail_localize_rws_languagecloud/tests/test_update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_update_translated_pages.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.core.management import call_command
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -70,6 +72,29 @@ class TestUpdateTranslatedPages(TestCase):
         LanguageCloudProject.objects.create(
             translation_source=self.source,
             source_last_updated_at=self.source.last_updated_at,
+            internal_status=LanguageCloudProject.STATUS_NEW,
+            lc_project_status=LanguageCloudStatus.IN_PROGRESS,
+            lc_project_id="proj",
+        )
+
+        call_command("update_translated_pages")
+
+        self.assertEqual(0, LanguageCloudProjectSettings.objects.count())
+
+    def test_should_skip_pages_with_ongoing_and_completed_lc_projects(self):
+        # Old, completed LC project
+        LanguageCloudProject.objects.create(
+            translation_source=self.source,
+            source_last_updated_at=self.source.last_updated_at,
+            internal_status=LanguageCloudProject.STATUS_IMPORTED,
+            lc_project_status=LanguageCloudStatus.ARCHIVED,
+            lc_project_id="proj",
+        )
+
+        # New, ongoing LC project
+        LanguageCloudProject.objects.create(
+            translation_source=self.source,
+            source_last_updated_at=self.source.last_updated_at + timedelta(days=1),
             internal_status=LanguageCloudProject.STATUS_NEW,
             lc_project_status=LanguageCloudStatus.IN_PROGRESS,
             lc_project_id="proj",

--- a/wagtail_localize_rws_languagecloud/tests/test_update_translated_pages.py
+++ b/wagtail_localize_rws_languagecloud/tests/test_update_translated_pages.py
@@ -1,0 +1,51 @@
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+from wagtail.core.models import Locale
+
+from wagtail_localize.models import Translation
+
+from ..models import LanguageCloudProject
+from .helpers import create_editor_user, create_test_page
+
+
+class TestUpdateTranslatedPages(TestCase):
+    def setUp(self):
+        self.locale_en = Locale.objects.get(language_code="en")
+        self.locale_fr = Locale.objects.create(language_code="fr")
+        self.locale_de = Locale.objects.create(language_code="de")
+        self.user = create_editor_user()
+        self.client.force_login(self.user)
+
+        # First make a page
+        self.page, self.source = create_test_page(
+            title="Test page",
+            slug="test-page",
+            test_charfield="Some test translatable content",
+        )
+        self.page.last_published_at = timezone.now()
+        self.page.save()
+
+        # Then translate it into the other languages
+        fr_translation = Translation.objects.create(
+            source=self.source,
+            target_locale=self.locale_fr,
+        )
+        fr_translation.save_target(publish=True)
+        de_translation = Translation.objects.create(
+            source=self.source,
+            target_locale=self.locale_de,
+        )
+        de_translation.save_target(publish=True)
+
+    def test_should_create_language_cloud_project(self):
+        call_command("update_translated_pages")
+        lc_project = LanguageCloudProject.objects.get(source=self.source)
+
+        self.assertTrue(lc_project)
+
+    def test_should_skip_creating_language_cloud_project(self):
+        self.fail()
+
+    def test_only_set_locales_are_translated(self):
+        self.fail()


### PR DESCRIPTION
This PR introduces a new command called `update_translated_pages` which syncs translations on recently published pages and queues them up to be translated on LanguageCloud.

"Recently published" pages are pages whose content has been updated and published, but whose translations have not yet been synced.

For example:

```gherkin
Given I have an English page
  And the page has translations enabled for French
 When I update the content of the English page
  And I publish the page
  And I run `python manage.py update_translated_pages`
 Then Wagtail syncs the English page content to French
  And sends the page to be translated on RWS LanguageCloud
```

A few things to note:

- Pages that have never been translated will not be synced. (Only translated pages can be synced.)
- Pages that have pending translations on RWS LanguageCloud will be skipped.

The command comes with a `--dry-run` option so you can check what the script is going to do.

The command also sends an email to Wagtail admin editors with a summary of pages that have been synced or skipped.